### PR TITLE
Fix parsing on 32bit systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+* [BUGFIX] Fix parsing on 32bit systems. #58
+
 # v0.2.0 / unreleased
 
 - [CHANGE] Rename label in `bind_incoming_requests_total` from `name` to `opcode`

--- a/bind/bind.go
+++ b/bind/bind.go
@@ -123,28 +123,28 @@ type TaskManager struct {
 // Counter represents a single counter value.
 type Counter struct {
 	Name    string `xml:"name,attr"`
-	Counter uint   `xml:",chardata"`
+	Counter uint64 `xml:",chardata"`
 }
 
 // Gauge represents a single gauge value.
 type Gauge struct {
 	Name  string `xml:"name"`
-	Gauge int    `xml:"counter"`
+	Gauge int64  `xml:"counter"`
 }
 
 // Task represents a single running task.
 type Task struct {
 	ID         string `xml:"id"`
 	Name       string `xml:"name"`
-	Quantum    uint   `xml:"quantum"`
-	References uint   `xml:"references"`
+	Quantum    uint64 `xml:"quantum"`
+	References uint64 `xml:"references"`
 	State      string `xml:"state"`
 }
 
 // ThreadModel contains task and worker information.
 type ThreadModel struct {
 	Type           string `xml:"type"`
-	WorkerThreads  uint   `xml:"worker-threads"`
-	DefaultQuantum uint   `xml:"default-quantum"`
-	TasksRunning   uint   `xml:"tasks-running"`
+	WorkerThreads  uint64 `xml:"worker-threads"`
+	DefaultQuantum uint64 `xml:"default-quantum"`
+	TasksRunning   uint64 `xml:"tasks-running"`
 }

--- a/bind/v2/v2.go
+++ b/bind/v2/v2.go
@@ -64,7 +64,7 @@ type Zone struct {
 
 type Counter struct {
 	Name    string `xml:"name"`
-	Counter uint   `xml:"counter"`
+	Counter uint64 `xml:"counter"`
 }
 
 // Client implements bind.Client and can be used to query a BIND v2 API.

--- a/bind/v3/v3.go
+++ b/bind/v3/v3.go
@@ -64,7 +64,7 @@ type Counters struct {
 
 type Counter struct {
 	Name    string `xml:"name"`
-	Counter int    `xml:"counter"`
+	Counter int64  `xml:"counter"`
 }
 
 // Client implements bind.Client and can be used to query a BIND v3 API.


### PR DESCRIPTION
Explicitly use 64-bit values for parsing data to avoid errors on 32-bit
systems.

Fixes: https://github.com/prometheus-community/bind_exporter/issues/43

Signed-off-by: Ben Kochie <superq@gmail.com>