### PR TITLE
Use uint64 for counters in v3 xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master / unreleased
   
+* [BUGFIX] Use uint64 for counters in v3 xml. #70
+
 ## 0.3.0 / 2020-01-08
 
 * [FEATURE] Support zone stats, enable some initial zone transfer metrics #49

--- a/bind/v3/v3.go
+++ b/bind/v3/v3.go
@@ -64,7 +64,7 @@ type Counters struct {
 
 type Counter struct {
 	Name    string `xml:"name"`
-	Counter int64  `xml:"counter"`
+	Counter uint64 `xml:"counter"`
 }
 
 // Client implements bind.Client and can be used to query a BIND v3 API.


### PR DESCRIPTION
Matches uint64 use in the v2 xml

Fixes: https://github.com/prometheus-community/bind_exporter/issues/69

Signed-off-by: Ben Kochie <superq@gmail.com>