### PR TITLE
Add current recursive clients metric

### DIFF
--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -188,7 +188,7 @@ var (
 			nil, nil,
 		),
 		"RecursClients": prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "recursive_clients_total"),
+			prometheus.BuildFQName(namespace, "", "recursive_clients"),
 			"Number of current recursive clients.",
 			nil, nil,
 		),

--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -187,6 +187,11 @@ var (
 			"Number of failed zone transfers.",
 			nil, nil,
 		),
+		"RecursClients": prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "recursive_clients_total"),
+			"Number of current recursive clients.",
+			nil, nil,
+		),
 	}
 	tasksRunning = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "tasks_running"),

--- a/bind_exporter_test.go
+++ b/bind_exporter_test.go
@@ -38,6 +38,7 @@ var (
 		`bind_zone_transfer_rejected_total 3`,
 		`bind_zone_transfer_success_total 25`,
 		`bind_zone_transfer_failure_total 1`,
+		`bind_recursive_clients_total 76`,
 	}
 	serverStatsV3 = combine(serverStatsV2, []string{
 		`bind_config_time_seconds 1.473202712e+09`,

--- a/bind_exporter_test.go
+++ b/bind_exporter_test.go
@@ -38,7 +38,7 @@ var (
 		`bind_zone_transfer_rejected_total 3`,
 		`bind_zone_transfer_success_total 25`,
 		`bind_zone_transfer_failure_total 1`,
-		`bind_recursive_clients_total 76`,
+		`bind_recursive_clients 76`,
 	}
 	serverStatsV3 = combine(serverStatsV2, []string{
 		`bind_config_time_seconds 1.473202712e+09`,

--- a/fixtures/v2.xml
+++ b/fixtures/v2.xml
@@ -1819,6 +1819,10 @@
           <counter>0</counter>
         </nsstat>
         <nsstat>
+          <name>RecursClients</name>
+          <counter>76</counter>
+        </nsstat>
+        <nsstat>
           <name>RPZRewrites</name>
           <counter>0</counter>
         </nsstat>

--- a/fixtures/v3/server
+++ b/fixtures/v3/server
@@ -63,7 +63,7 @@
       <counter name="UpdateDone">0</counter>
       <counter name="UpdateFail">0</counter>
       <counter name="UpdateBadPrereq">0</counter>
-      <counter name="RecursClients">0</counter>
+      <counter name="RecursClients">76</counter>
       <counter name="DNS64">0</counter>
       <counter name="RateDropped">0</counter>
       <counter name="RateSlipped">0</counter>


### PR DESCRIPTION
Adds recording of an additional metric, `recursive_clients_total`.

Bind limits the number of simultaneous recursive client looks. Reaching this limit will cause subsequent requests to fail, so recording/monitoring this metric feels sensible.