### PR TITLE
Fix Gauge type for large gauges

### DIFF
--- a/bind/bind.go
+++ b/bind/bind.go
@@ -142,7 +142,7 @@ type ZoneCounter struct {
 // Gauge represents a single gauge value.
 type Gauge struct {
 	Name  string `xml:"name"`
-	Gauge int64  `xml:"counter"`
+	Gauge uint64 `xml:"counter"`
 }
 
 // Task represents a single running task.

--- a/fixtures/v3/server
+++ b/fixtures/v3/server
@@ -182,6 +182,10 @@
           <name>NXDOMAIN</name>
           <counter>1</counter>
         </rrset>
+        <rrset>
+          <name>#A</name>
+          <counter>18446744073709551603</counter>
+        </rrset>
       </cache>
       <counters type="adbstat">
         <counter name="nentries">1021</counter>


### PR DESCRIPTION
Bind xml v3 gauges are actually uint64, Cache bind.Gauge is listed as
"counter" in the XML, but it's really a uint64 gauge.

Fixes: https://github.com/prometheus-community/bind_exporter/issues/69

Signed-off-by: Ben Kochie <superq@gmail.com>