### PR TITLE
Add zone serial numbers as metrics

### DIFF
--- a/bind/bind.go
+++ b/bind/bind.go
@@ -93,6 +93,7 @@ const (
 type Statistics struct {
 	Server      Server
 	Views       []View
+	ZoneViews   []ZoneView
 	TaskManager TaskManager
 }
 
@@ -114,6 +115,12 @@ type View struct {
 	ResolverQueries []Counter
 }
 
+// View represents statistics for a single BIND zone view.
+type ZoneView struct {
+	Name     string
+	ZoneData []ZoneCounter
+}
+
 // TaskManager contains information about all running tasks.
 type TaskManager struct {
 	Tasks       []Task      `xml:"tasks>task"`
@@ -124,6 +131,12 @@ type TaskManager struct {
 type Counter struct {
 	Name    string `xml:"name,attr"`
 	Counter uint64 `xml:",chardata"`
+}
+
+// Counter represents a single zone counter value.
+type ZoneCounter struct {
+	Name   string
+	Serial uint64
 }
 
 // Gauge represents a single gauge value.

--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -205,6 +205,11 @@ var (
 		"Total number of available worker threads.",
 		nil, nil,
 	)
+	zoneSerial = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "zone_serial"),
+		"Zone serial number.",
+		[]string{"view", "zone_name"}, nil,
+	)
 )
 
 type collectorConstructor func(*bind.Statistics) prometheus.Collector
@@ -325,6 +330,14 @@ func (c *viewCollector) Collect(ch chan<- prometheus.Metric) {
 			)
 		} else {
 			level.Warn(logger).Log("msg", "Error parsing RTT", "err", err)
+		}
+	}
+
+	for _, v := range c.stats.ZoneViews {
+		for _, z := range v.ZoneData {
+			ch <- prometheus.MustNewConstMetric(
+				zoneSerial, prometheus.CounterValue, float64(z.Serial), v.Name, z.Name,
+			)
 		}
 	}
 }

--- a/bind_exporter_test.go
+++ b/bind_exporter_test.go
@@ -61,6 +61,7 @@ var (
 		`bind_resolver_query_duration_seconds_bucket{view="_default",le="0.8"} 187375`,
 		`bind_resolver_query_duration_seconds_bucket{view="_default",le="1.6"} 188409`,
 		`bind_resolver_query_duration_seconds_bucket{view="_default",le="+Inf"} 227755`,
+		`bind_zone_serial{view="_default",zone_name="TEST_ZONE"} 123`,
 	}
 	taskStats = []string{
 		`bind_tasks_running 8`,
@@ -195,6 +196,7 @@ func newV3Server() *httptest.Server {
 		"/xml/v3/server": "fixtures/v3/server",
 		"/xml/v3/status": "fixtures/v3/status",
 		"/xml/v3/tasks":  "fixtures/v3/tasks",
+		"/xml/v3/zones":  "fixtures/v3/zones",
 	}
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if f, ok := m[r.RequestURI]; ok {

--- a/fixtures/v2.xml
+++ b/fixtures/v2.xml
@@ -8,6 +8,11 @@
           <name>_default</name>
           <zones>
             <zone>
+              <name>TEST_ZONE</name>
+              <rdataclass>IN</rdataclass>
+              <serial>123</serial>
+            </zone>
+            <zone>
               <name>0.in-addr.arpa/IN</name>
               <rdataclass>IN</rdataclass>
               <serial>1</serial>

--- a/fixtures/v3/zones
+++ b/fixtures/v3/zones
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/bind9.xsl"?>
+<statistics version="3.6">
+  <views>
+    <view name="_default">
+      <zones>
+        <zone name="TEST_ZONE" rdataclass="IN">
+          <type>builtin</type>
+          <serial>123</serial>
+        </zone>
+      </zones>
+    </view>
+  </views>
+</statistics>


### PR DESCRIPTION
This patch provides zone serial numbers as metrics:

```
bind_zone_serial{name="168.192.in-addr.arpa",rdataclass="IN",view="_default"} 1
bind_zone_serial{name="TEST_ZONE",rdataclass="IN",view="_default"} 123
bind_zone_serial{name="version.bind",rdataclass="CH",view="_bind"} 0
```