### PR TITLE
Update prometheus/client_golang to v1.11.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/go-kit/log v0.2.0
-	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/common v0.32.1
 	github.com/prometheus/exporter-toolkit v0.7.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6


### PR DESCRIPTION
Update prometheus/client_golang to v1.11.1 due to [CVE-2022-21698](https://github.com/prometheus/client_golang/security/advisories/GHSA-cg3q-j54f-5p7p)