### PR TITLE
Refactor logger

### DIFF
--- a/bind_exporter_test.go
+++ b/bind_exporter_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus-community/bind_exporter/bind"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/expfmt"
@@ -152,7 +153,7 @@ type bindExporterTest struct {
 func (b bindExporterTest) run(t *testing.T) {
 	defer b.server.Close()
 
-	o, err := collect(NewExporter(b.version, b.server.URL, time.Second, b.groups))
+	o, err := collect(NewExporter(log.NewNopLogger(), b.version, b.server.URL, time.Second, b.groups))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Remove global logger var in favor of passing logger from main() to the Exporter struct.