### PR TITLE
Deprecate collection of task stats by default

### DIFF
--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -546,7 +546,7 @@ func main() {
 	kingpin.Flag("bind.stats-groups",
 		"Comma-separated list of statistics to collect",
 	).Default((&statisticGroups{
-		bind.ServerStats, bind.ViewStats, bind.TaskStats,
+		bind.ServerStats, bind.ViewStats,
 	}).String()).SetValue(&groups)
 
 	promlogConfig := &promlog.Config{}


### PR DESCRIPTION
Task stats were removed from BIND 9.19 onwards, which has started to appear in mainstream distros. See upstream merge request https://gitlab.isc.org/isc-projects/bind9/-/merge_requests/7537

Fixes: #172