### PR TITLE
Add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Host operating system**
+Output of `uname -a`
+
+**BIND version**
+Output of `named -v`
+
+**bind_exporter version**
+Output of `bind_exporter --version`
+
+**bind_exporter command-line flags**
+Please list all command-line flags used.
+
+**bind_exporter log output**
+Please include relevant log output inside a text block, e.g.
+```
+paste log output here
+```
+
+**What did you expect to see?**
+
+**What did you see instead?**
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Bug report issue template, using new GitHub workflow.

Based on node_exporter ISSUE_TEMPLATE.md.