### PR TITLE
Add metric 'rpz_rewrites' to serverMetricStats

### DIFF
--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -202,6 +202,11 @@ var (
 			"Number of current recursive clients.",
 			nil, nil,
 		),
+		"RPZRewrites": prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "rpz_rewrites"),
+			"Number of response policy zone rewrites.",
+			nil, nil,
+		),
 	}
 	tasksRunning = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "tasks_running"),

--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -203,7 +203,7 @@ var (
 			nil, nil,
 		),
 		"RPZRewrites": prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "rpz_rewrites"),
+			prometheus.BuildFQName(namespace, "", "response_policy_zone_rewrites_total"),
 			"Number of response policy zone rewrites.",
 			nil, nil,
 		),


### PR DESCRIPTION
Add prometheus metric "bind_rpz_rewrites" corresponding to RPZRewrites bind exported counter. 

[Name Server Statistics Counters](https://bind9.readthedocs.io/en/v9.16.20/reference.html#name-server-statistics-counters)  / RPZRewrites