### PR TITLE
Cleanup golangci-lint config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,13 +16,6 @@ jobs:
       - run: make
       - prometheus/store_artifact:
           file: bind_exporter
-  codespell:
-    docker:
-      - image: cimg/python:3.11
-    steps:
-      - checkout
-      - run: pip install codespell
-      - run: codespell --skip=".git,./vendor,ttar,go.mod,go.sum,*pem" -L uint,packages\',uptodate
 workflows:
   version: 2
   bind_exporter:
@@ -33,10 +26,6 @@ workflows:
               only: /.*/
       - prometheus/build:
           name: build
-          filters:
-            tags:
-              only: /.*/
-      - codespell:
           filters:
             tags:
               only: /.*/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
   enable:
     - misspell
     - revive
+    - sloglint
 
 issues:
   exclude-rules:
@@ -15,8 +16,6 @@ linters-settings:
     exclude-functions:
       # Used in HTTP handlers, any error is handled by the server itself.
       - (net/http.ResponseWriter).Write
-      # Never check for logger errors.
-      - (github.com/go-kit/log.Logger).Log
   revive:
     rules:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter


### PR DESCRIPTION
* Remove obsolete go-kit exception.
* Remove codespell CI step in favor of misspell plugin.
* Enable sloglint plugin.