### PR TITLE
Migrate to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,53 +1,33 @@
 ---
+# Prometheus has switched to GitHub action.
+# Circle CI is not disabled repository-wise so that previous pull requests
+# continue working.
+# This file does not generate any CircleCI workflow.
+
 version: 2.1
-orbs:
-  prometheus: prometheus/prometheus@0.17.1
+
 executors:
-  # Whenever the Go version is updated here, .promu.yml should
-  # also be updated.
   golang:
     docker:
-      - image: cimg/go:1.25
+      - image: busybox
+
 jobs:
-  test:
+  noopjob:
     executor: golang
+
     steps:
-      - prometheus/setup_environment
-      - run: make
-      - prometheus/store_artifact:
-          file: bind_exporter
+      - run:
+          command: "true"
+
 workflows:
   version: 2
   bind_exporter:
     jobs:
-      - test:
-          filters:
-            tags:
-              only: /.*/
-      - prometheus/build:
-          name: build
-          filters:
-            tags:
-              only: /.*/
-      - prometheus/publish_master:
-          context: org-context
-          docker_hub_organization: prometheuscommunity
-          quay_io_organization: prometheuscommunity
-          requires:
-            - test
-            - build
+      - noopjob
+    triggers:
+      - schedule:
+          cron: "0 0 30 2 *"
           filters:
             branches:
-              only: master
-      - prometheus/publish_release:
-          context: org-context
-          docker_hub_organization: prometheuscommunity
-          quay_io_organization: prometheuscommunity
-          requires:
-            - test
-            - build
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+              only:
+                - main

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # Exclude configs synced from upstream prometheus/prometheus.
+    exclude-paths:
+      - .github/workflows/container_description.yml
+      - .github/workflows/golangci-lint.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+---
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main, master, 'release-*']
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  test_go:
+    name: Go tests
+    runs-on: ubuntu-latest
+    container:
+      # Whenever the Go version is updated here, .promu.yml
+      # should also be updated.
+      image: quay.io/prometheus/golang-builder:1.26-base
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: prometheus/promci-setup@5af30ba8c199a91d6c04ebdc3c48e630e355f62d # v0.1.0
+      - run: make GO_ONLY=1 SKIP_GOLANGCI_LINT=1
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        thread: [ 0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: prometheus/promci/build@9c86752f3395e08c57719af549cc455d8e2c2514 # v0.7.0
+        with:
+          parallelism: 4
+          thread: ${{ matrix.thread }}
+
+  publish_main:
+    name: Publish main branch artifacts
+    runs-on: ubuntu-latest
+    needs: [test_go, build]
+    if: |
+      (github.event_name == 'push' && github.event.ref == 'refs/heads/main')
+      ||
+      (github.event_name == 'push' && github.event.ref == 'refs/heads/master')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: prometheus/promci/publish_main@9c86752f3395e08c57719af549cc455d8e2c2514 # v0.7.0
+        with:
+          docker_hub_organization: prometheuscommunity
+          docker_hub_password: ${{ secrets.docker_hub_password }}
+          quay_io_organization: prometheuscommunity
+          quay_io_password: ${{ secrets.quay_io_password }}
+
+  publish_release:
+    name: Publish release artefacts
+    runs-on: ubuntu-latest
+    needs: [test_go, build]
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: prometheus/promci/publish_release@9c86752f3395e08c57719af549cc455d8e2c2514 # v0.7.0
+        with:
+          docker_hub_organization: prometheuscommunity
+          docker_hub_password: ${{ secrets.docker_hub_password }}
+          quay_io_organization: prometheuscommunity
+          quay_io_password: ${{ secrets.quay_io_password }}
+          github_token: ${{ secrets.PROMBOT_GITHUB_TOKEN }}

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,6 @@
 go:
-    # This must match .circle/config.yml.
-    version: 1.25
+    # This must match .github/workflows/ci.yml.
+    version: 1.26
 repository:
     path: github.com/prometheus-community/bind_exporter
 build:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/bind_exporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
Migrate CI to GitHub Actions.
* Bump Go to 1.26.x.