### PR TITLE
fix: report bind_recursive_clients as a gauge

### DIFF
--- a/bind_exporter.go
+++ b/bind_exporter.go
@@ -208,6 +208,12 @@ var (
 			nil, nil,
 		),
 	}
+	// serverMetricGauges lists the serverMetricStats entries that report a
+	// current value rather than a running total. BIND reports them in the same
+	// statistics counters as the totals, so they have to be typed explicitly.
+	serverMetricGauges = map[string]struct{}{
+		"RecursClients": {},
+	}
 	tasksRunning = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "tasks_running"),
 		"Number of running tasks.",
@@ -280,7 +286,7 @@ func (c *serverCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		if desc, ok := serverMetricStats[s.Name]; ok {
 			ch <- prometheus.MustNewConstMetric(
-				desc, prometheus.CounterValue, float64(s.Counter),
+				desc, serverMetricValueType(s.Name), float64(s.Counter),
 			)
 		}
 	}
@@ -292,10 +298,19 @@ func (c *serverCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, s := range c.stats.Server.ZoneStatistics {
 		if desc, ok := serverMetricStats[s.Name]; ok {
 			ch <- prometheus.MustNewConstMetric(
-				desc, prometheus.CounterValue, float64(s.Counter),
+				desc, serverMetricValueType(s.Name), float64(s.Counter),
 			)
 		}
 	}
+}
+
+// serverMetricValueType reports the value type to use for a serverMetricStats
+// entry.
+func serverMetricValueType(name string) prometheus.ValueType {
+	if _, ok := serverMetricGauges[name]; ok {
+		return prometheus.GaugeValue
+	}
+	return prometheus.CounterValue
 }
 
 type viewCollector struct {

--- a/bind_exporter_test.go
+++ b/bind_exporter_test.go
@@ -40,6 +40,8 @@ var (
 		`bind_zone_transfer_success_total 25`,
 		`bind_zone_transfer_failure_total 1`,
 		`bind_recursive_clients 76`,
+		// Current recursive clients is a gauge, not a counter.
+		`# TYPE bind_recursive_clients gauge`,
 		`bind_config_time_seconds 1.626325868e+09`,
 		`bind_response_rcodes_total{rcode="NOERROR"} 989812`,
 		`bind_response_rcodes_total{rcode="NXDOMAIN"} 33958`,


### PR DESCRIPTION
Fixes #98

`bind_recursive_clients` is the number of recursive clients currently being served, so it goes up and down. It was reported as a counter.

The cause is that `RecursClients` lives in `serverMetricStats`, and the emission loop typed every entry in that map as `CounterValue`. Every other entry in the map is a real total and ends in `_total`; this one doesn't, so the name was already right and only the type was wrong.

This marks `RecursClients` as a gauge and types the map entries explicitly. Sample values are unchanged.

Same kind of fix as `[BUGFIX] Fix Gauge type for large gauges #90`, so I've treated it as a bugfix rather than a breaking change. `rate()` over this series was never meaningful anyway, since it isn't monotonic.

The tests only asserted the sample line, so I added the type assertion too. It fails on master with `# TYPE bind_recursive_clients counter` and passes with the change.
